### PR TITLE
A few Meson improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,12 @@ project('GlibD', 'd',
     version: '2.0.0'
 )
 
+project_soversion = 0
+
 pkg_conf = import('pkgconfig')
 
-source_root = meson.source_root()
-build_root = meson.build_root()
+source_root = meson.current_source_dir()
+build_root = meson.current_build_dir()
 gen_dir = 'generated'
 
 #
@@ -29,7 +31,7 @@ message('Generating D interfaces from GIR...')
 girtod_gen = run_command(gir_to_d_prog,
                          '-i', gir_wrap_dir,
                          '-o', gir_d_intf_dir,
-						 '--print-files', 'relative,'+source_root)
+                         '--print-files', 'relative,' + source_root)
 if girtod_gen.returncode() != 0
     error('Unable to build D intefaces from GIR:\n' + girtod_gen.stderr())
 endif
@@ -38,22 +40,28 @@ gir_bind_dir = include_directories(gen_dir)
 # Enlist D GIR interface sources
 gir_binding_sources = girtod_gen.stdout().strip().split('\n')
 
-glibd = library('glibd-2',
+glibd = library('glibd-2.0',
     [gir_binding_sources],
     include_directories: [gir_bind_dir],
     dependencies: [glib_dep, gobject_dep, gio_dep],
     install: true,
-    soversion: 0,
+    soversion: project_soversion,
     version: meson.project_version())
 
-install_subdir(join_paths(meson.build_root(), gen_dir, 'glib'),    install_dir: 'include/d/glibd-2/')
-install_subdir(join_paths(meson.build_root(), gen_dir, 'gio'),     install_dir: 'include/d/glibd-2/')
-install_subdir(join_paths(meson.build_root(), gen_dir, 'gobject'), install_dir: 'include/d/glibd-2/')
-install_subdir(join_paths(meson.build_root(), gen_dir, 'gtkd'),    install_dir: 'include/d/glibd-2/')
+install_subdir(join_paths(build_root, gen_dir, 'glib'),    install_dir: 'include/d/glibd-2/')
+install_subdir(join_paths(build_root, gen_dir, 'gio'),     install_dir: 'include/d/glibd-2/')
+install_subdir(join_paths(build_root, gen_dir, 'gobject'), install_dir: 'include/d/glibd-2/')
+install_subdir(join_paths(build_root, gen_dir, 'gtkd'),    install_dir: 'include/d/glibd-2/')
 
 pkg_conf.generate(glibd,
-    name: 'GlibD-2',
-	subdirs: 'd/glib-2',
-	version: meson.project_version(),
+    name: 'glibd-2.0',
+    subdirs: 'd/glibd-2',
+    version: meson.project_version(),
     requires: [glib_dep, gio_dep, gobject_dep],
-	description: 'D bindings for the GLib C Utility Library.')
+    description: 'D bindings for the GLib C Utility Library.')
+
+# for use by others which embed this as subproject
+glibd_dep = declare_dependency(
+    link_with: [glibd],
+    include_directories: [gir_bind_dir]
+)


### PR DESCRIPTION
This patch does the following:

* Lowercase pkg-config name
This is a convention for pkg-config, while not really a technical requirement, it's nice to have names look uniform.

* Use same naming convention for glibd as for glib itself
Use the `-2.0` suffix instead of just `-2`, like glib does.

* Use build_root variable
It's available, so use it to shorten a few lines. I also made it use the *current* source/build directory, see the second point.

* Make it easy to use glibd in a subproject
The `glibd_dep` variable can be imported by other projects to easily use glibd in a subproject without relying on a copy that's installed system-wide.
Instead of using `meson.build_root()` etc. to determine the root directory, I made the code use the current directory as root. This allows usage in a subproject, because now the correct paths to the sources will be taken, instead of the root path to the main project. It's a pretty mean trap to fall in, actually.

* Don't mix tabs/spaces
Easy :-)

* Fix typo (glibd-2 instead of glib-2)
In the pkg-config generation. This made tools using Makefiles/ninja not find the GLibD include directory.

