### PR TITLE
meson: Fix gir-to-d call to work in package builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,6 @@ message('Generating D interfaces from GIR...')
 girtod_gen = run_command(gir_to_d_prog,
                          '-i', gir_wrap_dir,
                          '-o', gir_d_intf_dir,
-                         '-g', '/home/mike/Projects/gtkD/gir-2.64/',
                          '--print-files', 'relative,' + source_root)
 if girtod_gen.returncode() != 0
     error('Unable to build D intefaces from GIR:\n' + girtod_gen.stderr())


### PR DESCRIPTION
In 7a99cc5b5a1ae64a3df42d0c22e27e00e0293780, an accidental hardcoded
path for where the gtkd files were was added to the call to gir-to-d.

This broke the Fedora package build, so this change fixes it by
stripping that from the options passed to gir-to-d.