### PR TITLE
Print gir-to-d error messages again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ girtod_gen = run_command(gir_to_d_prog,
                          '-i', gir_wrap_dir,
                          '-o', gir_d_intf_dir,
                          '--print-files', 'relative,' + source_root,
-                         check: true)
+                         check: false)
 if girtod_gen.returncode() != 0
     error('Unable to build D intefaces from GIR:\n' + girtod_gen.stderr())
 endif


### PR DESCRIPTION
Hi!
We do check the error in the next line and print a nice message, so `check: true` is wrong here. With `check: true` we never get to see the actual error that gir-to-d has thrown under normal circumstances.

Cheers,
    Matthias
