### PR TITLE
Unbreak build with gobject-introspection >= 1.78

### DIFF
--- a/src/APILookupGLib.txt
+++ b/src/APILookupGLib.txt
@@ -1313,6 +1313,7 @@ code: end
 
 struct: String
 class: StringG
+version 2.78: noCode: new_take
 
 struct: Thread
 noCode: new


### PR DESCRIPTION
Regressed by https://github.com/gnome/gobject-introspection/commit/056a86ed5857
Fixes https://github.com/gtkd-developers/GlibD/issues/17

<details><summary>skipped duplicate</summary>

```d
	/**
	 * Creates a new #GString, initialized with the given string.
	 *
	 * After this call, @init belongs to the #GString and may no longer be
	 * modified by the caller. The memory of @data has to be dynamically
	 * allocated and will eventually be freed with g_free().
	 *
	 * Params:
	 *     init = initial text used as the string.
	 *         Ownership of the string is transferred to the #GString.
	 *         Passing %NULL creates an empty string.
	 *
	 * Returns: the new #GString
	 *
	 * Since: 2.78
	 *
	 * Throws: ConstructionException GTK+ fails to create the object.
	 */
	public this(string init)
	{
		auto __p = g_string_new_take(Str.toStringz(init));

		if(__p is null)
		{
			throw new ConstructionException("null returned by new_take");
		}

		this(cast(GString*) __p);
	}
```
</details>

Disclaimer: I don't use anything D (including GlibD) and didn't test GlibD consumers as FreeBSD doesn't package any.
