### PR TITLE
Add missing gthread-2.0 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ glib_dep          = dependency('glib-2.0')
 gmodule_dep       = dependency('gmodule-2.0')
 gobject_dep       = dependency('gobject-2.0')
 gio_dep           = dependency('gio-2.0')
+gthread_dep       = dependency('gthread-2.0')
 # The Glib gir files are part of the gobject introspection package.
 introspection_dep = dependency('gobject-introspection-1.0')
 
@@ -47,7 +48,7 @@ gir_binding_sources = girtod_gen.stdout().strip().split('\n')
 glibd = library('glibd-2.0',
     [gir_binding_sources],
     include_directories: [gir_bind_dir],
-    dependencies: [glib_dep, gmodule_dep, gobject_dep, gio_dep],
+    dependencies: [glib_dep, gmodule_dep, gobject_dep, gio_dep, gthread_dep],
     install: true,
     soversion: project_soversion,
     version: meson.project_version())
@@ -61,7 +62,7 @@ pkg_conf.generate(glibd,
     name: 'glibd-2.0',
     subdirs: 'd/glibd-2',
     version: meson.project_version(),
-    requires: [glib_dep, gmodule_dep, gio_dep, gobject_dep],
+    requires: [glib_dep, gmodule_dep, gio_dep, gobject_dep, gthread_dep],
     description: 'D bindings for the GLib C Utility Library.')
 
 # for use by others which embed this as subproject


### PR DESCRIPTION
Fixes the 'undefined symbol: g_thread_init' error when running programs that link to glibd.

Reason:
> To use g_thread_init() in your program, you have to link with the libraries that the command pkg-config —libs gthread-2.0 outputs.
- https://docs.gtk.org/glib/type_func.Thread.init.html