### PR TITLE
src: Add support for GioUnix / GioWin32 split

### DIFF
--- a/src/APILookup.txt
+++ b/src/APILookup.txt
@@ -51,3 +51,4 @@ copy: gtkd
 lookup: APILookupGLib.txt
 lookup: APILookupGObject.txt
 lookup: APILookupGio.txt
+lookup: APILookupGioUnix.txt

--- a/src/APILookupGio.txt
+++ b/src/APILookupGio.txt
@@ -292,31 +292,33 @@ code: start
 code: end
 
 version !Windows: start
-	struct: DesktopAppInfo
-	noCode: new_from_filename
-	code: start
-		/**
-		* Creates a new #GDesktopAppInfo.
-		*
-		* Params:
-		*     filename = the path of a desktop file, in the GLib filename encoding
-		*
-		* Return: a new #GDesktopAppInfo or %NULL on error.
-		*
-		* Throws: ConstructionException GTK+ fails to create the object.
-		*/
-		public static DesktopAppInfo createFromFilename(string filename)
-		{
-			auto p = g_desktop_app_info_new_from_filename(Str.toStringz(filename));
-
-			if(p is null)
+	version <2.86: start
+		struct: DesktopAppInfo
+		noCode: new_from_filename
+		code: start
+			/**
+			* Creates a new #GDesktopAppInfo.
+			*
+			* Params:
+			*     filename = the path of a desktop file, in the GLib filename encoding
+			*
+			* Return: a new #GDesktopAppInfo or %NULL on error.
+			*
+			* Throws: ConstructionException GTK+ fails to create the object.
+			*/
+			public static DesktopAppInfo createFromFilename(string filename)
 			{
-				throw new ConstructionException("null returned by g_desktop_app_info_new_from_filename");
-			}
+				auto p = g_desktop_app_info_new_from_filename(Str.toStringz(filename));
 
-			return new DesktopAppInfo(p, true);
-		}
-	code: end
+				if(p is null)
+				{
+					throw new ConstructionException("null returned by g_desktop_app_info_new_from_filename");
+				}
+
+				return new DesktopAppInfo(p, true);
+			}
+		code: end
+	version: end
 version: end
 
 struct: FileAttributeInfoList
@@ -415,8 +417,10 @@ array: set_value value length
 array: set_value_full value length
 
 version !Windows: start
-	struct: UnixMountEntry
-	class: UnixMountEntry
+	version <2.86: start
+		struct: UnixMountEntry
+		class: UnixMountEntry
+	version: end
 
 	struct: UnixSocketAddress
 	noCode: new_abstract
@@ -545,30 +549,32 @@ move: simple_async_report_gerror_in_idle SimpleAsyncResult
 move: simple_async_report_take_gerror_in_idle SimpleAsyncResult
 
 version !Windows: start
-	move: unix_is_mount_path_system_internal UnixMountEntry is_mount_path_system_internal
-	move: unix_mount_at UnixMountEntry at
-	move: unix_mount_compare UnixMountEntry compare
-	move: unix_mount_free UnixMountEntry free
-	move: unix_mount_get_device_path UnixMountEntry get_device_path
-	move: unix_mount_get_fs_type UnixMountEntry get_fs_type
-	move: unix_mount_get_mount_path UnixMountEntry get_mount_path
-	move: unix_mount_guess_can_eject UnixMountEntry guess_can_eject
-	move: unix_mount_guess_icon UnixMountEntry guess_icon
-	move: unix_mount_guess_name UnixMountEntry guess_name
-	move: unix_mount_guess_should_display UnixMountEntry guess_should_display
-	move: unix_mount_guess_symbolic_icon UnixMountEntry guess_symbolic_icon
-	move: unix_mount_is_readonly UnixMountEntry is_readonly
-	move: unix_mount_is_system_internal UnixMountEntry is_system_internal
-	move: unix_mount_points_changed_since UnixMountEntry points_changed_since
-	move: unix_mount_points_get UnixMountEntry mount_points_get
-	move: unix_mounts_changed_since UnixMountEntry mounts_changed_since
-	move: unix_mounts_get UnixMountEntry mounts_get
+	version <2.86: start
+		move: unix_is_mount_path_system_internal UnixMountEntry is_mount_path_system_internal
+		move: unix_mount_at UnixMountEntry at
+		move: unix_mount_compare UnixMountEntry compare
+		move: unix_mount_free UnixMountEntry free
+		move: unix_mount_get_device_path UnixMountEntry get_device_path
+		move: unix_mount_get_fs_type UnixMountEntry get_fs_type
+		move: unix_mount_get_mount_path UnixMountEntry get_mount_path
+		move: unix_mount_guess_can_eject UnixMountEntry guess_can_eject
+		move: unix_mount_guess_icon UnixMountEntry guess_icon
+		move: unix_mount_guess_name UnixMountEntry guess_name
+		move: unix_mount_guess_should_display UnixMountEntry guess_should_display
+		move: unix_mount_guess_symbolic_icon UnixMountEntry guess_symbolic_icon
+		move: unix_mount_is_readonly UnixMountEntry is_readonly
+		move: unix_mount_is_system_internal UnixMountEntry is_system_internal
+		move: unix_mount_points_changed_since UnixMountEntry points_changed_since
+		move: unix_mount_points_get UnixMountEntry mount_points_get
+		move: unix_mounts_changed_since UnixMountEntry mounts_changed_since
+		move: unix_mounts_get UnixMountEntry mounts_get
 
-	version 2.54: start
-		move: unix_mount_copy UnixMountEntry copy
-		move: unix_mount_for UnixMountEntry mount_for
+		version 2.54: start
+			move: unix_mount_copy UnixMountEntry copy
+			move: unix_mount_for UnixMountEntry mount_for
+		version: end
+
+		version 2.58: move: unix_mount_get_options UnixMountEntry get_options
+		version 2.60: move: unix_mount_get_root_path UnixMountEntry get_root_path
 	version: end
-
-	version 2.58: move: unix_mount_get_options UnixMountEntry get_options
-	version 2.60: move: unix_mount_get_root_path UnixMountEntry get_root_path
 version: end

--- a/src/APILookupGioUnix.txt
+++ b/src/APILookupGioUnix.txt
@@ -1,0 +1,58 @@
+# This file is part of gtkD.
+#
+# gtkD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# gtkD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with gtkD; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+#############################################
+### Definitions for wrapping Gtk+ ###########
+#############################################
+
+# must start with wrap
+wrap: gio_unix
+
+version !Windows: start
+    version 2.86: start
+        file: GioUnix-2.0.gir
+
+        struct: MountEntry
+        class: MountEntry
+
+        struct: DesktopAppInfo
+        noCode: new_from_filename
+        code: start
+            /**
+            * Creates a new #GDesktopAppInfo.
+            *
+            * Params:
+            *     filename = the path of a desktop file, in the GLib filename encoding
+            *
+            * Return: a new #GDesktopAppInfo or %NULL on error.
+            *
+            * Throws: ConstructionException GTK+ fails to create the object.
+            */
+            public static DesktopAppInfo createFromFilename(string filename)
+            {
+                auto p = g_desktop_app_info_new_from_filename(Str.toStringz(filename));
+
+                if(p is null)
+                {
+                    throw new ConstructionException("null returned by g_desktop_app_info_new_from_filename");
+                }
+
+                return new DesktopAppInfo(p, true);
+            }
+        code: end
+    version: end
+version: end

--- a/src/APILookupGioWin32.txt
+++ b/src/APILookupGioWin32.txt
@@ -1,0 +1,29 @@
+# This file is part of gtkD.
+#
+# gtkD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# gtkD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with gtkD; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+#############################################
+### Definitions for wrapping Gtk+ ###########
+#############################################
+
+# must start with wrap
+wrap: gio_win32
+
+version Windows: start
+    version 2.86: start
+        file: GioWin32-2.0.gir
+    version: end
+version: end


### PR DESCRIPTION
Since GLib 2.80 GioUnix and GioWin32 had been moved out from Gio typelib and gir files, so we need to reflect this in the D bindings.

And since 2.86.0 the split was finalized, so we need to adapt to that.

Closes: #23